### PR TITLE
Fix: Update .vercelignore to allow serverless functions

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,2 +1,5 @@
-# Ignore API files from Vite processing
-api/
+# Ignore specific API files from Vite processing (but keep serverless functions)
+api/projects-data.js
+api/rate-limiter.js
+api/webhook-validator.js
+api/message-fetcher.js


### PR DESCRIPTION
## Problem
The previous webhook fix was merged but the .vercelignore file still excludes the entire api/ directory, preventing Vercel from finding serverless functions.

## Solution
- Remove blanket api/ directory exclusion from .vercelignore
- Only ignore specific utility files that aren't serverless functions
- Allow webhook.js, projects.js, and health.js to be deployed as functions

## Changes
- ✅ Updated .vercelignore to exclude only utility files
- ✅ Allow serverless functions to be deployed
- ✅ Complete the webhook deployment fix

This completes the Vercel deployment fix by ensuring the serverless functions are not ignored.